### PR TITLE
Switch off BOM on file write

### DIFF
--- a/helpers/helpers_xxx_file.js
+++ b/helpers/helpers_xxx_file.js
@@ -141,7 +141,7 @@ function _open(file, codePage = 0) {
 function _save(file, value) {
 	const filePath = isCompatible('1.4.0') ? utils.SplitFilePath(file)[0] : utils.FileTest(file, 'split')[0]; //TODO: Deprecated
 	if (!_isFolder(filePath)) {_createFolder(filePath);}
-	if (_isFolder(filePath) && utils.WriteTextFile(file, value, true)) {
+	if (_isFolder(filePath) && utils.WriteTextFile(file, value, false)) {
 		return true;
 	}
 	console.log('Error saving to ' + file);


### PR DESCRIPTION
As a discussion starter: I encounter better compatibility with other applications (here: VLC) if playlists are written in UTF8 *without* BOM. How is it for you?

(As for the confusing branch name: I had thought remembering that some of the `EXTM3U` lines were the compatibility problem, not just the encoding.)