### PR TITLE
Automatic title for playlists created from selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
 - UI: added option to use bold font for playlists.
 - UI: added light shadows to playlists' text when using art as background to improve readability. It's now the default, but it may be disabled.
 - UI: added blur setting for the panel background art.
-- UI: added setting to tint UI elements (appart from the playlist list) while using the panel background art.
+- UI: added setting to tint UI elements (apart from the playlist list) while using the panel background art.
 ### Changed
 - UI: multiple optimizations to panel background art usage.
 ### Removed

--- a/main/playlist_manager/playlist_manager_menu.js
+++ b/main/playlist_manager/playlist_manager_menu.js
@@ -1037,7 +1037,7 @@ function createMenuRight() {
 		menu.newEntry({entryText: 'New playlist from selection...', func: () => {
 			const oldIdx = plman.ActivePlaylist;
 			if (oldIdx === -1) {return;}
-			const pls = list.add({bEmpty: true, name: 'Selection from ' + plman.GetPlaylistName(oldIdx).cut(10), bInputName: true});
+			const pls = list.add({bEmpty: true, name: list.generateTitleFromSelection(), bInputName: true});
 			if (pls) {
 				const playlistIndex = list.getPlaylistsIdxByObj([pls])[0];
 				const newIdx = plman.ActivePlaylist;

--- a/playlist_manager.js
+++ b/playlist_manager.js
@@ -978,7 +978,7 @@ if (!list.properties.bSetup[1]) {
 				}
 			} else {
 				if ((mask & 32) === 32 || list.index === -1) { // Create new playlist when pressing alt
-					const pls = list.add({bEmpty: true, name: 'Selection from ' + plman.GetPlaylistName(oldIdx).cut(10), bInputName: true});
+					const pls = list.add({bEmpty: true, name: list.generateTitleFromSelection(), bInputName: true});
 					if (pls) {
 						const playlistIndex = list.getPlaylistsIdxByObj([pls])[0];
 						const newIdx = plman.ActivePlaylist;


### PR DESCRIPTION
I wrote this for personal convenience. Maybe it's gonna be deemed useful.

When a playlist is created from selection, the script will suggest a "ARTIST[ - ALBUM]" naming scheme, where ARTIST will be "Various artists" if there are multiple different artists, and [ - ALBUM] will be empty if there are multiple different albums. Basically the behavior of foo_playlist_manager.

Limitations:
- Only the first value of tags containing multiple values is taken into account.
- No customization.

Idk why the GitHub online editor automatically removed a few empty lines from the files.