### PR TITLE
Fix scrollbar toggle

### DIFF
--- a/playlist_manager.js
+++ b/playlist_manager.js
@@ -756,14 +756,16 @@ if (!list.properties.bSetup[1]) {
 		tt: 'Double L. click to Show active or now playing playlist'
 	}) : null;
 
-	scrollBar.resize = function () {
-		this.x = window.Width - this.w;
-		this.y = list.getHeaderSize().h;
-		this.h = list.h - (this.y - list.y) - 1;
-		if (list.uiElements['Bottom toolbar'].enabled) { this.h -= bottomToolbar.h - _scale(1); }
-		this.rows = Math.max(list.items - list.rows, 0);
-		this.rowsPerPage = list.rows;
-	};
+	if (scrollBar) {
+		scrollBar.resize = function () {
+			this.x = window.Width - this.w;
+			this.y = list.getHeaderSize().h;
+			this.h = list.h - (this.y - list.y) - 1;
+			if (list.uiElements['Bottom toolbar'].enabled) { this.h -= bottomToolbar.h - _scale(1); }
+			this.rows = Math.max(list.items - list.rows, 0);
+			this.rowsPerPage = list.rows;
+		};
+	}
 
 	// Tracking a network drive?
 	if (!_hasRecycleBin(list.playlistsPath.match(/^(.+?:)/g)[0])) {
@@ -951,7 +953,9 @@ if (!list.properties.bSetup[1]) {
 		panel.size();
 		list.size();
 		bottomToolbar.on_size_buttn();
-		scrollBar.resize();
+		if (scrollBar && scrollBar.resize) {
+			scrollBar.resize();
+		}
 		pop.resize();
 	});
 

--- a/playlist_manager.js
+++ b/playlist_manager.js
@@ -953,7 +953,7 @@ if (!list.properties.bSetup[1]) {
 		panel.size();
 		list.size();
 		bottomToolbar.on_size_buttn();
-		if (scrollBar && scrollBar.resize) {
+		if (scrollBar) {
 			scrollBar.resize();
 		}
 		pop.resize();


### PR DESCRIPTION
At the moment, with the latest version of Playlist-Manager-SMP installed in a panel of the latest version of Spider Monkey Panel, when toggling the scrollbar off via Playlist manager settings... -> Panel UI -> UI elements -> Scrollbar, the panel enters a crash loop with the following error:
<img width="814" height="503" alt="MFNZcc8PDw" src="https://github.com/user-attachments/assets/7c73501b-f211-4eff-95e7-a91e15cf8db0" />
requiring manual change of UI elements -> Scrollbar.enabled back to true from Spider Monkey Panel Configuration to restore it.

Wrapping the function definition for scrollBar.resize() and its invocation in addEventListener('on_size', (width, height) with a conditional wrapper that checks whether the scrollBar exists in the first place fixes the issue by avoiding situations where scrollBar is null.

Both guards are required as the crash will still occur if only one of them is present.

There might be other actions that trigger the crash when the scrollbar is disabled, but this at least allows the panel to initialise.